### PR TITLE
nuevas consultas de analisis

### DIFF
--- a/Consultas/Analysis/AvgScrobblingsPerArtist.sql
+++ b/Consultas/Analysis/AvgScrobblingsPerArtist.sql
@@ -1,0 +1,12 @@
+-- Avg scrobbles per track
+SELECT
+	Artist,
+	COUNT(*) AS Scrobblings,
+	COUNT(DISTINCT Song) AS Songs,
+	COUNT(*)/COUNT(DISTINCT Song) AS ScrobblingsPerSong
+FROM
+	Scrobblings_fix
+GROUP BY
+	Artist
+ORDER BY
+	ScrobblingsPerSong DESC;

--- a/Consultas/Analysis/GapsBetweenArtist.sql
+++ b/Consultas/Analysis/GapsBetweenArtist.sql
@@ -1,0 +1,33 @@
+-- Largest time passed between two scrobbles of the same artist
+WITH ScrobblingsWithDaysBetween AS (
+    SELECT
+        Artist,
+        CAST(Fecha_GMT AS DATE) AS Fecha,
+        LAG(CAST(Fecha_GMT AS DATE), 1) OVER(PARTITION BY Artist
+            ORDER BY CAST(Fecha_GMT AS DATE)) AS EndDate,
+        DATEDIFF(DAY, LAG(CAST(Fecha_GMT AS DATE), 1) OVER(PARTITION BY Artist
+            ORDER BY CAST(Fecha_GMT AS DATE)), CAST(Fecha_GMT AS DATE)) AS DaysBetween
+    FROM Scrobblings_fix
+	GROUP BY
+	Artist,
+	Fecha_GMT
+	--HAVING COUNT(*) > 1
+),
+RankedScrobblings AS (
+    SELECT
+        Artist,
+        Fecha,
+        EndDate,
+        DaysBetween,
+        ROW_NUMBER() OVER(PARTITION BY Artist ORDER BY DaysBetween DESC) AS RowNum
+    FROM ScrobblingsWithDaysBetween
+)
+SELECT
+    Artist,
+    Fecha,
+    EndDate,
+    DaysBetween,
+	ROUND(CAST(DaysBetween/365.25 AS FLOAT),1) AS YearsBetween
+FROM RankedScrobblings
+WHERE RowNum = 1 AND DaysBetween IS NOT NULL
+ORDER BY DaysBetween DESC;

--- a/Consultas/Analysis/NewArtistsByMonth.sql
+++ b/Consultas/Analysis/NewArtistsByMonth.sql
@@ -1,0 +1,32 @@
+-- New artists in a single month
+WITH ArtistsFirstMonth AS (
+    SELECT
+        Artist,
+        MIN(Year_Month) AS FirstMonth
+    FROM
+        Scrobblings_fix
+    GROUP BY
+        Artist
+), -- Esta CTE Calcula los artistas distintos
+ArtistsPerMonth AS (
+    SELECT
+        Year_Month,
+        COUNT(DISTINCT Artist) AS TotalArtists
+    FROM
+        Scrobblings_fix
+    GROUP BY
+        Year_Month
+)
+SELECT
+    afm.FirstMonth,
+    COUNT(DISTINCT afm.Artist) AS Debutantes,
+    apm.TotalArtists,
+	ROUND(CAST(COUNT(DISTINCT afm.Artist) * 1.0 / apm.TotalArtists AS FLOAT), 2) AS Ratio
+FROM
+    ArtistsFirstMonth AS afm
+LEFT JOIN
+    ArtistsPerMonth AS apm ON afm.FirstMonth = apm.Year_Month
+GROUP BY
+    afm.FirstMonth, apm.TotalArtists
+ORDER BY
+    afm.FirstMonth;

--- a/Consultas/Analysis/OneHitWonders.sql
+++ b/Consultas/Analysis/OneHitWonders.sql
@@ -1,0 +1,12 @@
+-- One hit wonders
+SELECT
+	Artist,
+	COUNT(*) AS Scrobblings,
+	COUNT(DISTINCT Song) AS Songs
+FROM
+	Scrobblings_fix
+GROUP BY
+	Artist
+HAVING COUNT(DISTINCT Song) = 1
+ORDER BY
+	Scrobblings DESC

--- a/Consultas/Analysis/OngoingGapsBetweenArtists.sql
+++ b/Consultas/Analysis/OngoingGapsBetweenArtists.sql
@@ -1,0 +1,17 @@
+-- Ongoing gaps between artists
+/*
+última fecha menos la última reproducción
+*/
+SELECT
+	Artist, 
+	CAST(MIN(Fecha_GMT) AS DATE) AS FirstScrobbling,
+	CAST(MAX(Fecha_GMT) AS DATE) AS LastScrobbling,
+	DATEDIFF(DAY, CAST(MAX(Fecha_GMT) AS DATE), CAST(GETDATE() AS DATE)) AS DaysSinceLastScrobbling,
+	ROUND(CAST(DATEDIFF(DAY, MAX(Fecha_GMT), GETDATE()) AS FLOAT) / 365.25, 1) AS Years,
+	COUNT(*) AS Scrobblings
+FROM
+	Scrobblings_fix
+GROUP BY
+	Artist
+ORDER BY
+	DaysSinceLastScrobbling DESC;

--- a/Consultas/Analysis/WeeksPerArtist.sql
+++ b/Consultas/Analysis/WeeksPerArtist.sql
@@ -1,0 +1,22 @@
+-- Weeks per Artist
+/*
+Número de semanas distintas por artista
+Set datefirst 1 toma lunes como primer día de la semana
+*/
+SET DATEFIRST 1;
+
+SELECT
+	Artist,
+	-- DATEPART(WEEK, Fecha_GMT) AS NumSemana,
+	-- DATEPART(YEAR, Fecha_GMT) As Year,
+	--CONCAT(DATEPART(YEAR, Fecha_GMT), DATEPART(WEEK, Fecha_GMT)) AS Concatenacion,
+	COUNT(DISTINCT(CONCAT(DATEPART(YEAR, Fecha_GMT), DATEPART(WEEK, Fecha_GMT)))) AS Weeks,
+	COUNT(*) AS Scrobblings,
+	CAST(COUNT(*)/COUNT(DISTINCT(CONCAT(DATEPART(YEAR, Fecha_GMT), DATEPART(WEEK, Fecha_GMT)))) AS FLOAT) AS ScrobblingsPerWeel
+FROM
+	Scrobblings_fix
+GROUP BY
+	Artist
+ORDER BY
+	Weeks DESC,
+	Scrobblings DESC;


### PR DESCRIPTION
Se añaden nuevas consultas para analisis de los datos

        - **AvgScrobblingsPerArtist**: Promedio de Scrobblings por canción por artista
        - **GapsBetweenArtist**: Mayor cantidad de tiempo (dd y YYYY) entre la última y penúltima reproducción de un artista
        - **NewArtistsByMonth**: Cantidad de artistas nuevos por mes y ratio entre el total de escuchados
        - **OneHitWonders**: Artistas con más reproducciones, pero solo una canción escuchada
        - **OngoingGapsBetweenArtists**: Artistas con la mayor diferencia de tiempo entre el último día y su última reproducción
        - **WeeksPerArtist**: Cantidad de semanas por artista
